### PR TITLE
add new postgres flavoured package with ability to output inserted ids

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,12 @@ script:
   - dotnet build src/Badger.Data.sln -c Release 
   - dotnet test src/Badger.Data.Tests/Badger.Data.Tests.csproj -c Release --filter ExcludeFromTravis!=True
   - dotnet pack src/Badger.Data/Badger.Data.csproj -c Release -o nuget -p:PackageVersion=$PACKAGE_VERSION -p:FileVersion=$PACKAGE_VERSION
+  - dotnet pack src/Badger.Data.Postgres/Badger.Data.Postgres.csproj -c Release -o nuget -p:PackageVersion=$PACKAGE_VERSION -p:FileVersion=$PACKAGE_VERSION
 deploy:
   skip_cleanup: true
   provider: script
-  script: dotnet nuget push src/Badger.Data/nuget/Badger.Data.*.nupkg -k $NUGET_KEY -s https://nuget.org
+  script: 
+    - dotnet nuget push src/Badger.Data/nuget/Badger.Data.*.nupkg -k $NUGET_KEY -s https://nuget.org
+    - dotnet nuget push src/Badger.Data.Postgres/nuget/Badger.Data.Postgres.*.nupkg -k $NUGET_KEY -s https://nuget.org
   on:
     branch: master

--- a/src/Badger.Data.Postgres/Badger.Data.Postgres.csproj
+++ b/src/Badger.Data.Postgres/Badger.Data.Postgres.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <LangVersion>7.1</LangVersion>
+    <PackageVersion>1.0.0</PackageVersion>
+    <PackageId>Badger.Data.Postgres</PackageId>
+    <AssemblyName>Badger.Data.Postgres</AssemblyName>
+    <Description>Simple Database access for Postgres</Description>
+    <Authors>Tim Barker;Matt Holland</Authors>
+    <PackageProjectUrl>https://github.com/timbarker/Badger.Data</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/timbarker/Badger.Data/blob/master/LICENSE</PackageLicenseUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Badger.Data\Badger.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Badger.Data.Postgres/IPostgresCommandSession.cs
+++ b/src/Badger.Data.Postgres/IPostgresCommandSession.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Badger.Data.Postgres
+{
+    public interface IPostgresCommandSession : ICommandSession
+    {
+        InsertResult<T> ExecuteInsert<T>(ICommand insertCommand, string identifierName);
+        Task<InsertResult<T>> ExecuteInsertAsync<T>(ICommand command, string identifierName, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Badger.Data.Postgres/IPostgresSessionFactory.cs
+++ b/src/Badger.Data.Postgres/IPostgresSessionFactory.cs
@@ -1,0 +1,9 @@
+using System.Data;
+
+namespace Badger.Data.Postgres
+{
+    public interface IPostgresSessionFactory : ISessionFactory
+    {
+        IPostgresCommandSession CreateInsertCommandSession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted);
+    }
+}

--- a/src/Badger.Data.Postgres/InsertResult.cs
+++ b/src/Badger.Data.Postgres/InsertResult.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Badger.Data.Postgres
+{
+    public class InsertResult<T>
+    {
+        public int RowsAffected { get; private set; }
+        public T Id { get; private set; }
+        public bool IdSuccessfullyCast { get; private set; }
+
+        public static InsertResult<T> CreateResult(int rowsAffected, object id)
+        {
+            if (id is T idAsT)
+            {
+                return new InsertResult<T>
+                {
+                    Id = idAsT,
+                    RowsAffected = rowsAffected,
+                    IdSuccessfullyCast = true
+                };
+            }
+            try
+            {
+                return new InsertResult<T>
+                {
+                    Id = (T)Convert.ChangeType(id, typeof(T)),
+                    RowsAffected = rowsAffected,
+                    IdSuccessfullyCast = true
+                };
+            }
+            catch (InvalidCastException)
+            {
+                return new InsertResult<T>
+                {
+                    Id = default,
+                    RowsAffected = rowsAffected
+                };
+            }
+        }
+    }
+}

--- a/src/Badger.Data.Postgres/PostgresCommandSession.cs
+++ b/src/Badger.Data.Postgres/PostgresCommandSession.cs
@@ -1,0 +1,42 @@
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Badger.Data.Commands;
+using Badger.Data.Sessions;
+
+namespace Badger.Data.Postgres
+{
+    internal sealed class PostgresCommandSession : CommandSession, IPostgresCommandSession
+    {
+        private readonly ParameterFactory _parameterFactory;
+
+        public PostgresCommandSession(DbConnection connection, ParameterFactory parameterFactory,
+            IsolationLevel isolationLevel) : base(connection, parameterFactory, isolationLevel)
+        {
+            _parameterFactory = parameterFactory;
+        }
+
+        public InsertResult<T> ExecuteInsert<T>(ICommand insertCommand, string identifierName)
+        {
+            var command = CreateCommand();
+            var builder = new CommandBuilder(command, _parameterFactory);
+            builder.AsInsert(identifierName);
+
+            var rowsAffected = insertCommand.Prepare(builder).Execute();
+            return InsertResult<T>.CreateResult(rowsAffected, command.Parameters[identifierName].Value);
+        }
+
+        public async Task<InsertResult<T>> ExecuteInsertAsync<T>(ICommand insertCommand, string identifierName,
+            CancellationToken cancellationToken = default)
+        {
+            var command = CreateCommand();
+            var builder = new CommandBuilder(command, _parameterFactory);
+            builder.AsInsert(identifierName);
+
+            var rowsAffected =
+                await insertCommand.Prepare(builder).ExecuteAsync(cancellationToken).ConfigureAwait(false);
+            return InsertResult<T>.CreateResult(rowsAffected, command.Parameters[identifierName].Value);
+        }
+    }
+}

--- a/src/Badger.Data.Postgres/PostgresSessionFactory.cs
+++ b/src/Badger.Data.Postgres/PostgresSessionFactory.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Badger.Data.Sessions;
+
+namespace Badger.Data.Postgres
+{
+    public class PostgresSessionFactory : IPostgresSessionFactory
+    {
+        private readonly Config _config;
+        private readonly ParameterFactory _parameterFactory;
+
+        public static IPostgresSessionFactory With(Action<Config> configBuilder)
+        {
+            var config = new Config();
+            configBuilder.Invoke(config);
+            var sessionFactory = new PostgresSessionFactory(config);
+            return sessionFactory;
+        }
+
+        private PostgresSessionFactory(Config config)
+        {
+            _config = config;
+            _parameterFactory = new ParameterFactory(_config.ProviderFactory, _config.ParameterHandlers);
+        }
+
+        public ICommandSession CreateCommandSession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
+        {
+            return new CommandSession(CreateConnection(), _parameterFactory, isolationLevel);
+        }
+
+        public IQuerySession CreateQuerySession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
+        {
+            return new QuerySession(CreateConnection(), _parameterFactory, isolationLevel);
+        }
+
+        private DbConnection CreateConnection()
+        {
+            var connection = _config.ProviderFactory.CreateConnection();
+            connection.ConnectionString = _config.ConnectionString;
+            return connection;
+        }
+
+        public IPostgresCommandSession CreateInsertCommandSession(IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
+        {
+            return new PostgresCommandSession(CreateConnection(), _parameterFactory, isolationLevel);
+        }
+    }
+}

--- a/src/Badger.Data.Tests/Badger.Data.Tests.csproj
+++ b/src/Badger.Data.Tests/Badger.Data.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Badger.Data.Postgres\Badger.Data.Postgres.csproj" />
     <ProjectReference Include="..\Badger.Data\Badger.Data.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Badger.Data.Tests/Postgres/PostgresCommandTest.cs
+++ b/src/Badger.Data.Tests/Postgres/PostgresCommandTest.cs
@@ -1,10 +1,64 @@
+using System;
+using Badger.Data.Postgres;
+using Dapper;
+using Shouldly;
+using Xunit;
+
 namespace Badger.Data.Tests.Postgres
 {
     public class PostgresCommandTest : CommandTest<PostgresTestFixture>
     {
+        private readonly PostgresTestFixture _fixture;
+        private readonly IPostgresSessionFactory _postgresSessionFactory;
+
         public PostgresCommandTest(PostgresTestFixture fixture)
             : base (fixture)
-        {            
+        {
+            _fixture = fixture;
+            _postgresSessionFactory = fixture.CreatePostgresSessionFactory();
+        }
+
+        class InsertPersonCommand : ICommand
+        {
+            private readonly string _name;
+            private readonly DateTime _dob;
+
+            public InsertPersonCommand(string name, DateTime dob)
+            {
+                this._name = name;
+                this._dob = dob;
+            }
+
+            public IPreparedCommand Prepare(ICommandBuilder builder)
+            {
+                return builder
+                    .WithSql("insert into people(name, dob) values (@name, @dob) returning id")
+                    .WithParameter("name", _name)
+                    .WithParameter("dob", _dob)
+                    .Build();
+            }
+        }
+
+        [Fact]
+        public void SessionInsertShouldAlterOneRowAndReturnGeneratedId()
+        {
+            var name = Guid.NewGuid().ToString();
+            var dob = new DateTime(1990, 5, 20);
+            long id;
+
+            using (var session = _postgresSessionFactory.CreateInsertCommandSession())
+            {
+                var executionResult = session.ExecuteInsert<long>(new InsertPersonCommand(name, dob), "id");
+                executionResult.RowsAffected.ShouldBe(1);
+                id = executionResult.Id;
+                session.Commit();
+            }
+
+            var queryResult = _fixture.Connection.QuerySingle<Person>(
+                "select name, dob from people where id = @id", new { id });
+
+            queryResult.Dob.ShouldBe(dob);
+            queryResult.Name.ShouldBe(name);
         }
     }
 }

--- a/src/Badger.Data.Tests/Postgres/PostgresTestFixture.cs
+++ b/src/Badger.Data.Tests/Postgres/PostgresTestFixture.cs
@@ -1,3 +1,4 @@
+using Badger.Data.Postgres;
 using Dapper;
 using Npgsql;
 
@@ -12,6 +13,13 @@ namespace Badger.Data.Tests.Postgres
             : base (NpgsqlFactory.Instance)
         {
             InitTestDatabase();
+        }
+
+        public IPostgresSessionFactory CreatePostgresSessionFactory()
+        {
+            return PostgresSessionFactory.With(config =>
+                config.WithConnectionString(ConnectionString)
+                    .WithProviderFactory(ProviderFactory));
         }
 
         protected override void CreateTestTables()

--- a/src/Badger.Data.sln
+++ b/src/Badger.Data.sln
@@ -1,10 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.15
+VisualStudioVersion = 15.0.27130.2026
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Badger.Data", "Badger.Data\Badger.Data.csproj", "{DC00C819-6595-4663-94F7-5CC4D6860FA0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Badger.Data.Tests", "Badger.Data.Tests\Badger.Data.Tests.csproj", "{90A79412-381D-40AC-824F-34F5C759D71E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Badger.Data.Postgres", "Badger.Data.Postgres\Badger.Data.Postgres.csproj", "{88CF7C47-158D-4F75-8217-EB1AD566EFC6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +42,18 @@ Global
 		{90A79412-381D-40AC-824F-34F5C759D71E}.Release|x64.Build.0 = Release|Any CPU
 		{90A79412-381D-40AC-824F-34F5C759D71E}.Release|x86.ActiveCfg = Release|Any CPU
 		{90A79412-381D-40AC-824F-34F5C759D71E}.Release|x86.Build.0 = Release|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Debug|x64.Build.0 = Debug|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Debug|x86.Build.0 = Debug|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Release|x64.ActiveCfg = Release|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Release|x64.Build.0 = Release|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Release|x86.ActiveCfg = Release|Any CPU
+		{88CF7C47-158D-4F75-8217-EB1AD566EFC6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Badger.Data/AssemblyInfo.cs
+++ b/src/Badger.Data/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Badger.Data.Postgres")]

--- a/src/Badger.Data/Builder.cs
+++ b/src/Badger.Data/Builder.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Linq;
 
 namespace Badger.Data
 {
@@ -20,6 +19,12 @@ namespace Badger.Data
         public TBuilder WithParameter(string name, string value, int length)
         {
             Command.Parameters.Add(_parameterFactory.Create(name, value, length));
+            return this as TBuilder;
+        }
+
+        public TBuilder WithOutputParameter(string name)
+        {
+            Command.Parameters.Add(_parameterFactory.CreateOutputParameter(name));
             return this as TBuilder;
         }
 

--- a/src/Badger.Data/Commands/CommandBuilder.cs
+++ b/src/Badger.Data/Commands/CommandBuilder.cs
@@ -13,5 +13,10 @@ namespace Badger.Data.Commands
         {
             return new PreparedCommand(Command);
         }
+
+        public ICommandBuilder AsInsert(string identifierName)
+        {
+            return WithOutputParameter(identifierName);
+        }
     }
 }

--- a/src/Badger.Data/ICommandBuilder.cs
+++ b/src/Badger.Data/ICommandBuilder.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace Badger.Data
 {
     /// <summary>
-    /// Builder to create a PreparedCommand
+    /// Builder to create a PreparedCommand.
     /// </summary>
     public interface ICommandBuilder
     {
@@ -32,7 +32,7 @@ namespace Badger.Data
         ICommandBuilder WithParameter(string name, string value, int length);
 
         /// <summary>
-        /// Specifies a command timeout for the query
+        /// Specifies a command timeout for the query.
         /// </summary>
         /// <param name="timeout">the desired timeout.</param>
         /// <returns></returns>

--- a/src/Badger.Data/ParameterFactory.cs
+++ b/src/Badger.Data/ParameterFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
 
@@ -28,6 +29,18 @@ namespace Badger.Data
                 handler.Invoke(value, parameter);
             else
                 DefaultParameterHandler(value, parameter, size);
+
+            return parameter;
+        }
+
+        public DbParameter CreateOutputParameter(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException("Paramter name must not be null or empty", nameof(name));
+
+            var parameter = _dbProviderFactory.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Direction = ParameterDirection.Output;
 
             return parameter;
         }

--- a/src/Badger.Data/Sessions/CommandSession.cs
+++ b/src/Badger.Data/Sessions/CommandSession.cs
@@ -6,7 +6,7 @@ using Badger.Data.Commands;
 
 namespace Badger.Data.Sessions
 {
-    internal sealed class CommandSession : Session, ICommandSession
+    internal class CommandSession : Session, ICommandSession
     {
         private readonly ParameterFactory _parameterFactory;
 


### PR DESCRIPTION
I went down quite a lot of rabbit holes but this is the best compromise I could come up with for now. Main challenges for including the functionality in the core package:
* sqlite would require something like http://www.sqlite.org/c3ref/last_insert_rowid.html
* mssql might be a bit easier but I didn't want to run it locally 💣 

In terms of style for the satellite package again that could be improved but I'll let you review the PR and tell me which direction you want to go with that.

Lastly the travis changes are untested apart from running the pack command locally.